### PR TITLE
Add Qt5 and SciPy-bundle to NESSI 2021.12

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -270,6 +270,8 @@ check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 if [[ ${exit_code} -ne 0 ]]; then
   eb --last-log
   cat $(eb --last-log)
+  mkdir node_tmp
+  cp -r /tmp/$USER/EESSI node_tmp/.
 fi
 
 # skip test step when installing SciPy-bundle on aarch64,

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -267,7 +267,7 @@ fail_msg="Installation of Qt5 failed, that's frustrating..."
 $EB --disable-cleanup-tmpdir Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 exit_code=$?
 check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
-if [[ "${exit_code} -ne 0 ]]; then
+if [[ ${exit_code} -ne 0 ]]; then
   eb --last-log
   cat $(eb --last-log)
 fi

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -261,26 +261,26 @@ fail_msg="Installation of Perl failed, this never happens..."
 $EB Perl-5.30.2-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2640
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-#echo ">> Installing Qt5..."
-#ok_msg="Qt5 installed, phieuw, that was a big one!"
-#fail_msg="Installation of Qt5 failed, that's frustrating..."
-#$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
-## skip test step when installing SciPy-bundle on aarch64,
-## to dance around problem with broken numpy tests;
-## cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/11959
-#echo ">> Installing SciPy-bundle"
-#ok_msg="SciPy-bundle installed, yihaa!"
-#fail_msg="SciPy-bundle installation failed, bummer..."
-#SCIPY_EC=SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
-#if [[ "$(uname -m)" == "aarch64" ]]; then
-#  $EB $SCIPY_EC --robot --skip-test-step
-#else
-#  $EB $SCIPY_EC --robot
-#fi
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
+echo ">> Installing Qt5..."
+ok_msg="Qt5 installed, phieuw, that was a big one!"
+fail_msg="Installation of Qt5 failed, that's frustrating..."
+$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+# skip test step when installing SciPy-bundle on aarch64,
+# to dance around problem with broken numpy tests;
+# cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/11959
+echo ">> Installing SciPy-bundle"
+ok_msg="SciPy-bundle installed, yihaa!"
+fail_msg="SciPy-bundle installation failed, bummer..."
+SCIPY_EC=SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  $EB $SCIPY_EC --robot --skip-test-step
+else
+  $EB $SCIPY_EC --robot
+fi
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 #echo ">> Installing GROMACS..."
 #ok_msg="GROMACS installed, wow!"
 #fail_msg="Installation of GROMACS failed, damned..."

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -266,7 +266,6 @@ ok_msg="Qt5 installed, phieuw, that was a big one!"
 fail_msg="Installation of Qt5 failed, that's frustrating..."
 $EB --disable-cleanup-tmpdir Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 exit_code=$?
-check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 if [[ ${exit_code} -ne 0 ]]; then
   echo "Qt5 exit code: '${exit_code}'"
   eb --last-log
@@ -280,6 +279,7 @@ else
   mkdir /eessi_bot_job/node_tmp
   cp -r /tmp/* /eessi_bot_job/node_tmp/.
 fi
+check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 
 # skip test step when installing SciPy-bundle on aarch64,
 # to dance around problem with broken numpy tests;

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -264,7 +264,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing Qt5..."
 ok_msg="Qt5 installed, phieuw, that was a big one!"
 fail_msg="Installation of Qt5 failed, that's frustrating..."
-$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
+$EB --disable-cleanup-tmpdir Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 exit_code=$?
 check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 if [[ "${exit_code} -ne 0 ]]; then

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -271,7 +271,7 @@ if [[ ${exit_code} -ne 0 ]]; then
   eb --last-log
   cat $(eb --last-log)
   mkdir node_tmp
-  cp -r /tmp/$USER/EESSI node_tmp/.
+  cp -r /tmp/* node_tmp/.
 fi
 
 # skip test step when installing SciPy-bundle on aarch64,

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -261,25 +261,23 @@ fail_msg="Installation of Perl failed, this never happens..."
 $EB Perl-5.30.2-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2640
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-echo ">> Installing Qt5..."
-ok_msg="Qt5 installed, phieuw, that was a big one!"
-fail_msg="Installation of Qt5 failed, that's frustrating..."
-$EB --disable-cleanup-tmpdir --parallel=1 Qt5-5.14.1-GCCcore-9.3.0.eb --robot
-exit_code=$?
-if [[ ${exit_code} -ne 0 ]]; then
-  echo "Qt5 exit code: '${exit_code}'"
-  eb --last-log
-  cat $(eb --last-log)
-  mkdir /eessi_bot_job/node_tmp
-  cp -r /tmp/* /eessi_bot_job/node_tmp/.
+if [[ ${EESSI_SOFTWARE_SUBDIR} == "x86_64/intel/haswell" ]]; then
+  echo "Skipping Qt5 on '${EESSI_SOFTWARE_SUBDIR}'"
 else
-  echo "Qt5 exit code: '${exit_code}'"
-  eb --last-log
-  cat $(eb --last-log)
-  mkdir /eessi_bot_job/node_tmp
-  cp -r /tmp/* /eessi_bot_job/node_tmp/.
+  echo ">> Installing Qt5..."
+  ok_msg="Qt5 installed, phieuw, that was a big one!"
+  fail_msg="Installation of Qt5 failed, that's frustrating..."
+  $EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
+  exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "Qt5 exit code: '${exit_code}'"
+    eb --last-log
+    cat $(eb --last-log)
+    mkdir /eessi_bot_job/node_tmp
+    cp -r /tmp/* /eessi_bot_job/node_tmp/.
+  fi
+  check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 fi
-check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 
 # skip test step when installing SciPy-bundle on aarch64,
 # to dance around problem with broken numpy tests;

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -264,7 +264,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing Qt5..."
 ok_msg="Qt5 installed, phieuw, that was a big one!"
 fail_msg="Installation of Qt5 failed, that's frustrating..."
-$EB --disable-cleanup-tmpdir Qt5-5.14.1-GCCcore-9.3.0.eb --robot
+$EB --disable-cleanup-tmpdir --parallel=1 Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 exit_code=$?
 if [[ ${exit_code} -ne 0 ]]; then
   echo "Qt5 exit code: '${exit_code}'"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -265,7 +265,12 @@ echo ">> Installing Qt5..."
 ok_msg="Qt5 installed, phieuw, that was a big one!"
 fail_msg="Installation of Qt5 failed, that's frustrating..."
 $EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
-check_exit_code $? "${ok_msg}" "${fail_msg}"
+exit_code=$?
+check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
+if [[ "${exit_code} -ne 0 ]]; then
+  eb --last-log
+  cat $(eb --last-log)
+fi
 
 # skip test step when installing SciPy-bundle on aarch64,
 # to dance around problem with broken numpy tests;

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -268,10 +268,17 @@ $EB --disable-cleanup-tmpdir Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 exit_code=$?
 check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 if [[ ${exit_code} -ne 0 ]]; then
+  echo "Qt5 exit code: '${exit_code}'"
   eb --last-log
   cat $(eb --last-log)
-  mkdir node_tmp
-  cp -r /tmp/* node_tmp/.
+  mkdir /eessi_bot_job/node_tmp
+  cp -r /tmp/* /eessi_bot_job/node_tmp/.
+else
+  echo "Qt5 exit code: '${exit_code}'"
+  eb --last-log
+  cat $(eb --last-log)
+  mkdir /eessi_bot_job/node_tmp
+  cp -r /tmp/* /eessi_bot_job/node_tmp/.
 fi
 
 # skip test step when installing SciPy-bundle on aarch64,


### PR DESCRIPTION
Qt5 couldn't be built for `haswell`. We'll have to revisit that at a later point in time (see issue  https://github.com/trz42/software-layer/issues/30).